### PR TITLE
chore(socialite): add profile scope to obtain email

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -15,6 +15,11 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
+    protected $scopes = ['profile.basic'];
+
+    /**
+     * {@inheritdoc}
+     */
     protected function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase(
@@ -55,10 +60,18 @@ class Provider extends AbstractProvider
     {
         $user = $user['streamlabs'];
 
-        return (new User())->setRaw($user)->map([
+        $newUser = (new User())->setRaw($user)->map([
             'id'       => $user['id'],
+            'nickname' => $user['display_name'],
             'name'     => $user['display_name'],
+            'email'    => $user['email']
         ]);
+
+        if (isset($user['prime'])) {
+            $newUser['prime'] = $user['prime'];
+        }
+
+        return $newUser;
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ return Socialite::with('streamlabs')->redirect();
 
 - ``id``
 - ``name``
+- ``email``
 
 ### Reference
 


### PR DESCRIPTION
Add basic scope profile.basic, this allows returned user object to obtain Email address of user.

There is a special use case where we want to get the prime status of a user. This option however will for now be only available for internal Streamlabs applications. This is the reason why I add the prime only when it's present. 

This change is made by an official Streamlabs Employee Please check my https://www.linkedin.com/in/jarivdberg to verify.